### PR TITLE
[FIX] Dashboard alignment

### DIFF
--- a/bin/lib/utils/utils.js
+++ b/bin/lib/utils/utils.js
@@ -186,13 +186,11 @@ function configValidation(config, type, value, message) {
 	const configType = typeof config[type];
 
 	if (configType === 'boolean'){ // accept 'true' but not 'false'
-		console.log('configType boolean')
 		if (config[type] === false) {
 			throw new Error(message);
 		}
 	} else if (configType === 'function') {
 		// accept 'true' but not 'false', or a fn definition
-		console.log('configType function');
 		if(! config[type](value)) {
 			throw new Error(config.errorMsg);
 		}

--- a/index.js
+++ b/index.js
@@ -225,7 +225,7 @@ app.post('/lexicon/:lang', (req, res) => {
 		!req.query.hasOwnProperty('firstChunkOnly') || !!req.query.firstChunkOnly; // default is firstChunkOnly=true
 	return Lexicon.search(lexQuery)
 		.then(async text => {
-			const combinedText = 'Lexicon Search Term: ' + lexQuery + '\n\n' + text;
+			const combinedText = 'Lexicon Search Term: ' + lexQuery + '\n\n' + extract(text);
 			const translations = await generateTranslations(
 				translators,
 				combinedText,

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -210,7 +210,7 @@ function setElementsHeight() {
 	for (var i = 0; i < textBody[0].children.length; i++) {
 		var largest;
 		applyToAllElements(i, element => {
-			if (!largest || largest.offsetHeight < element.offsetHeight) {
+			if (!largest || largest.clientHeight < element.clientHeight) {
 				largest = element;
 			}
 		});
@@ -218,9 +218,11 @@ function setElementsHeight() {
 		applyToAllElements(i, element => {
 			element.setAttribute(
 				'style',
-				'min-height:' + largest.offsetHeight + 'px'
+				'min-height:' + largest.clientHeight + 'px'
 			);
 		});
+
+		largest = false;
 	}
 }
 


### PR DESCRIPTION
- ensure lexicon text is extracted
- corrected alignment lost with change from let to var, by resetting the var.