### PR TITLE
[UPDATE] remove Google

### DIFF
--- a/bin/lib/translators/multi-translator.js
+++ b/bin/lib/translators/multi-translator.js
@@ -3,12 +3,11 @@ if (process.env.NODE_ENV !== 'production') require('dotenv').config();
 const Utils = require('../utils/utils');
 
 const Deepl  = require('./deepl').init(Utils.processEnv('DEEPL_API_KEY'));
-const Google = require('./google').init(Utils.processEnv('GOOGLE_PROJECT_ID'));
 const AWS = require('./aws').init();
 const SETTINGS = require('../utils/translator-settings');
 const Tracking = require('../utils/tracking');
 
-const translatorEntities = [Deepl, Google, AWS];
+const translatorEntities = [Deepl, AWS];
 const translatorMap = {}; // unpack entity info into useful structure
 
 translatorEntities.map( entity => {

--- a/index.js
+++ b/index.js
@@ -26,9 +26,6 @@ if (process.env.NODE_ENV === 'production') {
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
 
-const googleTokenPath = path.resolve(`${__dirname}/keyfile.json`);
-fs.writeFileSync(googleTokenPath, Utils.processEnv('GOOGLE_CREDS'));
-
 const CAPI = require('./bin/lib/ft/capi').init(Utils.processEnv('FT_API_KEY'));
 const Translator = require('./bin/lib/translators/multi-translator');
 const Audio = require('./bin/lib/utils/get-audio');
@@ -82,7 +79,6 @@ app.post('/article/:uuid/:lang', (req, res, next) => {
 	res.langFrom = req.body.from;
 	const fromCache = req.body.fromCache;
 	const checkCache = req.body.checkCache;
-
 	res.translators = JSON.parse(req.body.translators);
 
 	if (fromCache) {

--- a/public/js/componentSecondIteration/main.js
+++ b/public/js/componentSecondIteration/main.js
@@ -192,7 +192,7 @@ function showTranslation(language) {
 			'Content-Type': 'application/x-www-form-urlencoded'
 		},
 		method: 'POST',
-		body: `translators=${JSON.stringify([translator])}&from=en`
+		body: `translators=${JSON.stringify([translator])}&from=en&checkCache=true`
 	};
 
 	if (localTranslations[`${languageCode.toLowerCase()}`]) {


### PR DESCRIPTION
## Description
We need to get rid of Google Translate because 💸

## Implementation
- remove keyfile generation from index (not needed, as there's no Google key left)
- remove Google from the multi-translator file (but keep the google library for ease of re-implementation)
- force cacheCheck on the demo pages so the translations are all loaded from S3.

## .env changes
Remove `GOOGLE_PROJECT_ID` and `GOOGLE_CREDS`
Note: `NEXT_TRANSLATOR` needs to remain et as `google` for the cached demo translations to work

![Alt Text](https://media.giphy.com/media/3owyoVTgJcXP5Y6CKk/giphy.gif)
